### PR TITLE
Fix StubFunc method

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -92,3 +92,27 @@ func TestStubFuncFail(t *testing.T) {
 		}()
 	}
 }
+
+func TestMultipleStubFuncs(t *testing.T) {
+	var f1 = func() int {
+		return 100
+	}
+	var f2 = func() int {
+		return 200
+	}
+	var f3 = func() int {
+		return 300
+	}
+
+	stubs := StubFunc(&f1, 1).StubFunc(&f2, 2)
+	expectVal(t, f1(), 1)
+	expectVal(t, f2(), 2)
+
+	stubs.StubFunc(&f3, 3)
+	expectVal(t, f3(), 3)
+
+	stubs.Reset()
+	expectVal(t, f1(), 100)
+	expectVal(t, f2(), 200)
+	expectVal(t, f3(), 300)
+}

--- a/gostub.go
+++ b/gostub.go
@@ -68,7 +68,7 @@ func (s *Stubs) StubFunc(funcVarToStub interface{}, stubVal ...interface{}) *Stu
 			funcType.NumOut(), len(stubVal)))
 	}
 
-	return Stub(funcVarToStub, FuncReturning(funcPtrType.Elem(), stubVal...).Interface())
+	return s.Stub(funcVarToStub, FuncReturning(funcPtrType.Elem(), stubVal...).Interface())
 }
 
 // FuncReturning creates a new function with type funcType that returns results.


### PR DESCRIPTION
Hi Prashant! Hope you've been well!

We came across an apparent bug in the `Stubs.StubFunc` method. Presumably, if this works:
```
defer gostub.Stub(&v1, 1).Stub(&v2, 2).Reset()
```
then this should too:
```
defer gostub.StubFunc(&f1, 1).StubFunc(&f2, 2).Reset()
```
However, as of now, this sort of thing behaves incorrectly. (Try running the test I added without the corresponding change in `gostub.go`.)

Would it be possible to fix this? No rush at all; it's easy enough to work around.