### PR TITLE
gostub: update travis builds with updated go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
   - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - tip
 
 before_install:
   - go get github.com/axw/gocov/gocov
@@ -13,3 +16,6 @@ before_install:
 script:
   - $HOME/gopath/bin/goveralls -service=travis-ci
 
+matrix:
+  allow_failures:
+  - go: tip


### PR DESCRIPTION
Updating the go versions for builds, also adding tip to ensure latest but allow it to fail. 